### PR TITLE
FileUploader: add case for video upload size

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -5,6 +5,9 @@ var util = require('util');
 
 var MAX_FILE_SIZE_BYTES = 15 * 1024 * 1024;
 var MAX_FILE_CHUNK_BYTES = 5 * 1024 * 1024;
+var MAX_VIDEO_SIZE_BYTES = 512 * 1024 * 1024;
+var MAX_VIDEO_CHUNK_BYTES =
+  parseInt(process.env.MAX_VIDEO_CHUNK_BYTES) || 15 * 1024 * 1024;
 
 /**
  * FileUploader class used to upload a file to twitter via the /media/upload (chunked) API.
@@ -42,9 +45,10 @@ FileUploader.prototype.upload = function (cb) {
       cb(err);
       return;
     } else {
+      var MAX_CHUNK_BYTES = bodyObj.MAX_CHUNK_BYTES || MAX_FILE_CHUNK_BYTES;
       var mediaTmpId = bodyObj.media_id_string;
       var chunkNumber = 0;
-      var mediaFile = fs.createReadStream(self._file_path, { highWaterMark: MAX_FILE_CHUNK_BYTES });
+      var mediaFile = fs.createReadStream(self._file_path, { highWaterMark: MAX_CHUNK_BYTES });
 
       mediaFile.on('data', function (chunk) {
         // Pause our file stream from emitting `data` events until the upload of this chunk completes.
@@ -128,25 +132,35 @@ FileUploader.prototype._initMedia = function (cb) {
   var mediaFileSizeBytes = fs.statSync(self._file_path).size;
   var shared = self._isSharedMedia;
   var media_category = 'tweet_image';
+  var MAX_FILE_BYTES = MAX_FILE_SIZE_BYTES;
+  var MAX_CHUNK_BYTES = MAX_FILE_CHUNK_BYTES;
+  if(mediaType.toLowerCase().indexOf('octet-stream') > -1) {
+    mediaType = 'video/mp4';
+  }
 
   if (mediaType.toLowerCase().indexOf('gif') > -1) {
     media_category = 'tweet_gif';
   } else if (mediaType.toLowerCase().indexOf('video') > -1) {
+    MAX_FILE_BYTES = MAX_VIDEO_SIZE_BYTES;
+    MAX_CHUNK_BYTES = MAX_VIDEO_CHUNK_BYTES;
     media_category = 'tweet_video';
   }
 
   // Check the file size - it should not go over 15MB for video.
   // See https://dev.twitter.com/rest/reference/post/media/upload-chunked
-  if (mediaFileSizeBytes < MAX_FILE_SIZE_BYTES) {
+  if (mediaFileSizeBytes < MAX_FILE_BYTES) {
     self._twit.post('media/upload', {
       'command': 'INIT',
       'media_type': mediaType,
       'total_bytes': mediaFileSizeBytes,
       'shared': shared,
       'media_category': media_category
-    }, cb);
+    }, function(err, bodyObj, resp) {
+      bodyObj.MAX_CHUNK_BYTES = MAX_CHUNK_BYTES;
+      cb(err, bodyObj, resp);
+    });
   } else {
-    var errMsg = util.format('This file is too large. Max size is %dB. Got: %dB.', MAX_FILE_SIZE_BYTES, mediaFileSizeBytes);
+    var errMsg = util.format('This file is too large. Max size is %dB. Got: %dB.', MAX_FILE_BYTES, mediaFileSizeBytes);
     cb(new Error(errMsg));
   }
 }


### PR DESCRIPTION
Twitter allows video to be 512MB, so limiting to 15MB is severely
limiting a lot of functionality. This will keep all formats not video to
remain the same while changing the allowed total file byte size and max
chunk byte size to allow for correct limits